### PR TITLE
pdf2html: use Ubuntu repository versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,17 @@ RUN sed -i 's/# deb-src/deb-src/g' /etc/apt/sources.list && \
                         libfontforge-dev libfontconfig-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cd /tmp && \
-    git clone https://github.com/fontforge/fontforge.git && \
-    cd fontforge && \
-    mkdir build && \
-    cd build && \
-    cmake -GNinja .. && \
-    ninja && \
-    ninja install && \
-    cd && rm -rf /tmp/fontforge
+# disable building fontforge manually, since fontforge-git is incompatible with pdf2html-git
+# for now, using the ubuntu version instead (libfontforge-dev)
+#RUN cd /tmp && \
+#    git clone https://github.com/fontforge/fontforge.git && \
+#    cd fontforge && \
+#    mkdir build && \
+#    cd build && \
+#    cmake -GNinja .. && \
+#    ninja && \
+#    ninja install && \
+#    cd && rm -rf /tmp/fontforge
 
 RUN cd /tmp && \
     git clone git://git.freedesktop.org/git/poppler/poppler && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,6 @@ RUN cd /tmp && \
     make install && \
     cd && rm -rf /tmp/pdf2htmlEX
 
-# TODO: Prevent pdf2htmlEX execution for now as it doesn't work
-RUN mv /usr/local/bin/pdf2htmlEX /usr/local/bin/pdf2htmlEX-notworking
-
 # Set correct environment variables.
 ENV HOME /root
 ENV RAILS_ENV production


### PR DESCRIPTION
Seems that `pdf2html` builds and runs just fine with the `fontforge` versions from the repositories. I did some basic testing, it seems to work the way it did before.

> SO.. the pdf2htmlEX sources have not (yet) been updated to use any fontforge after tag/20170731 (which most Ubuntu releases are still using).
(https://github.com/pdf2htmlEX/pdf2htmlEX/issues/42#issuecomment-555987352)

(issue #1 )