### PR TITLE
set $HOME for bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN ln -s /home/app/webapp/docker/sync_job.sh /etc/cron.weekly/sync_job.sh
 ENV SECRET_KEY_BASE "nokey"
 
 USER app
+ENV HOME "/home/app/"
 RUN cd /home/app/webapp && \
     bundle config set path 'vendor/bundle' && \
     bundle install --jobs 4


### PR DESCRIPTION
When I tried building the Docker image, some errors came up that `/root` wasn't writable during these steps:
```
spex:webapp$ bundle exec rake db:setup
spex:webapp$ bundle exec /home/app/webapp/script/init_3gpp.rb
```

This PR fixed the error and the setup proceeded.