### PR TITLE
Fix weekly cronjob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,9 @@ RUN mv /home/app/webapp/docker/webapp.sh /etc/my_init.d/webapp.sh
 RUN chown -R app /home/app/webapp
 
 # cron
-RUN ln -s /home/app/webapp/docker/sync_job.sh /etc/cron.weekly/sync_job.sh
+RUN cp /home/app/webapp/docker/sync_job.sh /etc/cron.weekly/sync_job && \
+    chown root:root /etc/cron.weekly/sync_job && \
+    chmod 755 /etc/cron.weekly/sync_job
 
 ENV SECRET_KEY_BASE "nokey"
 


### PR DESCRIPTION
`cron.weekly` is implemented using `run-parts`, which just runs any executable in a directory. Haha, no, executables must not have any dot in their name.

Besides, making sure that the script isn't writable for non-root users (wouldn't execute then, either).